### PR TITLE
fix: Update success-purchasing component to display 'E' instead of 'T…

### DIFF
--- a/src/app/core/components/success-purchasing/success-purchasing.component.html
+++ b/src/app/core/components/success-purchasing/success-purchasing.component.html
@@ -81,7 +81,7 @@
 
         <div class="letters" (click)="shareOnTelegram()">
           <div class="card">
-            <div class="card_face front">T</div>
+            <div class="card_face front">E</div>
             <div class="card_face back">
               <i class="fab fa-telegram"></i>
             </div>

--- a/src/app/features/Account/login/login.component.ts
+++ b/src/app/features/Account/login/login.component.ts
@@ -21,7 +21,8 @@ export class LoginComponent implements OnInit {
   
   ngOnInit(): void {
     google.accounts.id.initialize({
-      client_id:'720571637733-0dkqjkrolhqs2iq1vbbb4bigmacf4sje.apps.googleusercontent.com',
+      client_id: '266324222426-m4sb7dbnjncul86f8l2pqh15ktqlt9nv.apps.googleusercontent.com',
+      //client_id:'720571637733-0dkqjkrolhqs2iq1vbbb4bigmacf4sje.apps.googleusercontent.com',
       callback:(res:any)=>this.handlelogin(res)
     })
 


### PR DESCRIPTION
…' for Telegram sharing